### PR TITLE
Change challenge complexity based on failed logins #243

### DIFF
--- a/src/main/java/ch/sportchef/business/authentication/entity/Challenge.java
+++ b/src/main/java/ch/sportchef/business/authentication/entity/Challenge.java
@@ -1,0 +1,21 @@
+package ch.sportchef.business.authentication.entity;
+
+import lombok.Data;
+
+import javax.persistence.Entity;
+
+@Entity
+@Data
+public class Challenge {
+
+    private final String challenge;
+    private int tries = 0;
+
+    public Challenge(String challenge) {
+        this.challenge = challenge;
+    }
+
+    public void increaseTries() {
+        tries++;
+    }
+}


### PR DESCRIPTION
Normally when a user loges in, he now has to type only 5 characters. This still leaves 916132832 possibilities. However, if someone tries to hack the server (requests many challenges) the length of the generated challenges increases to up to 10 characters (8.39E17 possibilities). Furthermore, all (and so also the 5 character long challenges) do no more work after 10 tries. So an attack on the first few short challenges does not work either.
This solves issue #243.
